### PR TITLE
Add plugin creation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Create a new plugin with the following command:
 nextflow plugin create
 ```
 
-See the [Nextflow documentation](https://www.nextflow.io/docs/latest/guides/gradle-plugin#gradle-plugin-create) for more details.
+See [Creating a plugin](https://www.nextflow.io/docs/latest/guides/gradle-plugin#gradle-plugin-create) for more information.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
 # nf-plugin-template plugin
 
+## Creating your plugin
+
+The Nextflow plugin template is a scaffold for plugin development.
+The simplest way to create a new plugin is to use Nextflow to scaffold your files:
+
+```bash
+nextflow plugin create
+```
+
+See the [Nextflow documentation](https://www.nextflow.io/docs/latest/guides/gradle-plugin#gradle-plugin-create) for more details.
+
 ## Building
 
 To build the plugin:
+
 ```bash
 make assemble
 ```
@@ -22,12 +34,10 @@ Plugins can be published to a central plugin registry to make them accessible to
 Follow these steps to publish the plugin to the Nextflow Plugin Registry:
 
 1. Create a file named `$HOME/.gradle/gradle.properties`, where $HOME is your home directory. Add the following properties:
-
     * `npr.apiKey`: Your Nextflow Plugin Registry access token.
-
 2. Use the following command to package and create a release for your plugin on GitHub: `make release`.
 
 
 > [!NOTE]
 > The Nextflow Plugin registry is currently available as preview technology. Contact info@nextflow.io to learn how to get access to it.
-> 
+

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 ## Creating your plugin
 
 The Nextflow plugin template is a scaffold for plugin development.
-The simplest way to create a new plugin is to use Nextflow to scaffold your files:
+The simplest way to create a new plugin is to use the `nextflow plugin create` sub-command to create a plugin project based on the template.
+
+Create a new plugin with the following command:
 
 ```bash
 nextflow plugin create


### PR DESCRIPTION
Added instructions for creating a new Nextflow plugin using the scaffold command.

Note that the link to the docs will only work when https://github.com/nextflow-io/nextflow/pull/6033 is merged.