### PR TITLE
Fix link to Creating a plugin in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Create a new plugin with the following command:
 nextflow plugin create
 ```
 
-See [Creating a plugin](https://www.nextflow.io/docs/latest/guides/gradle-plugin#gradle-plugin-create) for more information.
+See [Creating a plugin](https://www.nextflow.io/docs/latest/guides/gradle-plugin.html#gradle-plugin-create) for more information.
 
 ## Building
 


### PR DESCRIPTION
This pull request updates the documentation in `README.md` to fix a broken link to the plugin creation guide. The link now correctly points to the intended section in the Nextflow documentation.