### PR TITLE
Use variable for Gradle command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,23 @@
+GRADLE := $(shell command -v gradle 2>/dev/null || echo ./gradlew)
+
 # Build the plugin
 assemble:
-	./gradlew assemble
+	$(GRADLE) assemble
 
 clean:
 	rm -rf .nextflow*
 	rm -rf work
 	rm -rf build
-	./gradlew clean
+	$(GRADLE) clean
 
 # Run plugin unit tests
 test:
-	./gradlew test
+	$(GRADLE) test
 
 # Install the plugin into local nextflow plugins dir
 install:
-	./gradlew install
+	$(GRADLE) install
 
 # Publish the plugin
 release:
-	./gradlew releasePlugin
+	$(GRADLE) releasePlugin


### PR DESCRIPTION
When trying to develop plugins in a [pixi](https://pixi.prefix.dev/latest/) environment, the `.gradlew` executable stops working because it is unable to find the installed Java executable (even though JAVA_HOME is correctly set). I found out that installing gradle in the environment does fix these issues. 

This PR changes the Makefile to use the gradle executable by default and if it cannot find that executable it will use the .gradlew executable instead